### PR TITLE
livestream-cloner, vue.js version explicitly set to 2 since it longer defaults to 2

### DIFF
--- a/machines/eb-livestream-origin/var/www/livestream_cloner/app/templates/index.html
+++ b/machines/eb-livestream-origin/var/www/livestream_cloner/app/templates/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     <link rel="stylesheet" type="text/css" href="/static/style.css">
-    <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2"></script>
 </head>
 <body>
     <div id="app" class="container">


### PR DESCRIPTION
The default vue version has changed from 2 to 3 which broke the current cloner web gui. This change fixes that.